### PR TITLE
Update actions/checkout in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -242,7 +242,7 @@ jobs:
     needs: upload
     steps:
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Release a Changelog
       uses: rasmus-saks/release-a-changelog-action@v1.0.1
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Setup Rust stable
         uses: actions-rs/toolchain@v1
         with:
@@ -37,7 +37,7 @@ jobs:
           - "x86-64"
     steps:
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Setup Rust ${{ matrix.rust-toolchain }}
       uses: actions-rs/toolchain@v1
       with:
@@ -66,7 +66,7 @@ jobs:
           - "x86-64"
     steps:
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Setup Rust stable
       uses: actions-rs/toolchain@v1
       with:
@@ -102,7 +102,7 @@ jobs:
     name: Publish crates
     steps:
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Setup Rust ${{ matrix.rust-toolchain }}
       uses: actions-rs/toolchain@v1
       with:
@@ -135,7 +135,7 @@ jobs:
       pull-requests: read
     steps:
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Release a Changelog
       uses: rasmus-saks/release-a-changelog-action@v1.0.1
       with:


### PR DESCRIPTION
Updates the `actions/checkout` action used in the GitHub Actions workflows to its newest major version.

Changes in [actions/checkout](https://github.com/actions/checkout):

> ## v3.5.2
> - Fix api endpoint for GHES
>
> ## v3.5.1
> - Fix slow checkout on Windows
>
> ## v3.5.0
> - Add new public key for known_hosts
>
> ## v3.4.0
> - Upgrade codeql actions to v2
> - Upgrade dependencies
> - Upgrade @actions/io
>
> ## v3.3.0
> - Implement branch list using callbacks from exec function
> - Add in explicit reference to private checkout options
> - Fix comment typos
>
> ## v3.2.0
> - Add GitHub Action to perform release
> - Fix status badge
> - Replace datadog/squid with ubuntu/squid Docker image
> - Wrap pipeline commands for submoduleForeach in quotes
> - Update @actions/io to 1.1.2
> - Upgrading version to 3.2.0
>
> ## v3.1.0
> - Use @actions/core `saveState` and `getState`
> - Add `github-server-url` input
>
> ## v3.0.2
> - Add input `set-safe-directory`
>
> ## v3.0.1
> - Fixed an issue where checkout failed to run in container jobs due to the new git setting `safe.directory`
> - Bumped various npm package versions
>
> ## v3.0.0
>
> - Update to node 16
