### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -60,10 +60,7 @@ jobs:
         - pp39-manylinux_x86_64
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+    - uses: dtolnay/rust-toolchain@stable
     - name: Build manylinux wheels
       uses: pypa/cibuildwheel@v2.11.3
       env:
@@ -97,10 +94,7 @@ jobs:
         - pp39-macosx_x86_64
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+    - uses: dtolnay/rust-toolchain@stable
     - name: Build manylinux wheels
       uses: pypa/cibuildwheel@v2.11.3
       env:
@@ -131,11 +125,9 @@ jobs:
         - cp311-macosx_arm64
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-        override: true
-        target: aarch64-apple-darwin
+        targets: aarch64-apple-darwin
     - name: Build manylinux wheels
       uses: pypa/cibuildwheel@v2.11.3
       env:
@@ -169,10 +161,7 @@ jobs:
         - pp39-win_amd64
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+    - uses: dtolnay/rust-toolchain@stable
     - name: Build manylinux wheels
       uses: pypa/cibuildwheel@v2.11.3
       env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,17 +11,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Rust stable
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt
       - name: Check code format
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
   test:
     name: Test (${{ matrix.rust-toolchain }}, ${{ matrix.cpu }})
     runs-on: ubuntu-latest
@@ -39,21 +33,16 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Setup Rust ${{ matrix.rust-toolchain }}
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
-        profile: minimal
         toolchain: ${{ matrix.rust-toolchain }}
-        override: true
     - name: Setup cache for cargo
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: target
         key: ${{ runner.os }}-cargo-${{ matrix.rust-toolchain }}
     - name: Test code
-      uses: actions-rs/cargo@v1
-      with:
-        env: RUSTFLAGS="--target-cpu=${{ matrix.cpu }}"
-        command: test
+      run: cargo test
   cover:
     name: Coverage (${{ matrix.cpu }})
     runs-on: ubuntu-latest
@@ -68,13 +57,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Setup Rust stable
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: Setup cache for cargo
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: target
         key: ${{ runner.os }}-cargo-${{ matrix.rust-toolchain }}
@@ -104,31 +89,15 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Setup Rust ${{ matrix.rust-toolchain }}
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: Package and publish lightmotif
-      uses: actions-rs/cargo@v1
-      with:
-        command: publish
-        args: -p lightmotif --token ${{ secrets.CRATES_IO_TOKEN }}
+      run: cargo publish -p lightmotif --token ${{ secrets.CRATES_IO_TOKEN }}
     - name: Package and publish lightmotif-transfac
-      uses: actions-rs/cargo@v1
-      with:
-        command: publish
-        args: -p lightmotif-transfac --token ${{ secrets.CRATES_IO_TOKEN }}
+      run: cargo publish -p lightmotif-transfac --token ${{ secrets.CRATES_IO_TOKEN }}
     - name: Package and publish lightmotif-tfmpvalue
-      uses: actions-rs/cargo@v1
-      with:
-        command: publish
-        args: -p lightmotif-tfmpvalue --token ${{ secrets.CRATES_IO_TOKEN }}
+      run: cargo publish -p lightmotif-tfmpvalue --token ${{ secrets.CRATES_IO_TOKEN }}
     - name: Package and publish lightmotif-py
-      uses: actions-rs/cargo@v1
-      with:
-        command: publish
-        args: -p lightmotif-py --token ${{ secrets.CRATES_IO_TOKEN }}
+      run: cargo publish -p lightmotif-py --token ${{ secrets.CRATES_IO_TOKEN }}
   release:
     environment: GitHub Releases
     runs-on: ubuntu-latest


### PR DESCRIPTION
The following updates are performed:
* update [`actions/cache`](https://github.com/actions/cache) to v3
* replace [unmaintained](https://github.com/actions-rs/toolchain/issues/216) `actions-rs/toolchain` by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain)
* replace unmaintained `actions-rs/cargo` by direct invocation of `cargo`